### PR TITLE
Borrow poly in ProverQuery so that upstream clients do not have to copy

### DIFF
--- a/src/math_utils.rs
+++ b/src/math_utils.rs
@@ -1,4 +1,4 @@
-use ark_ff::{Field, One};
+use ark_ff::One;
 use bandersnatch::Fr;
 /// Computes the inner product between two scalar vectors
 pub fn inner_product(a: &[Fr], b: &[Fr]) -> Fr {
@@ -17,6 +17,7 @@ pub fn powers_of(point: Fr, n: usize) -> Vec<Fr> {
 
 #[test]
 fn simple_vandemonde() {
+    use ark_ff::Field;
     use ark_std::test_rng;
     use ark_std::UniformRand;
     let rand_fr = Fr::rand(&mut test_rng());
@@ -24,9 +25,9 @@ fn simple_vandemonde() {
     let powers = powers_of(rand_fr, n);
 
     assert_eq!(powers[0], Fr::one());
-    assert_eq!(powers[n - 1], rand_fr.pow(&[(n - 1) as u64]));
+    assert_eq!(powers[n - 1], rand_fr.pow([(n - 1) as u64]));
 
     for (i, power) in powers.into_iter().enumerate() {
-        assert_eq!(power, rand_fr.pow(&[i as u64]))
+        assert_eq!(power, rand_fr.pow([i as u64]))
     }
 }

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -86,7 +86,7 @@ mod tests {
     #[test]
     fn test_vector_2() {
         let mut tr = Transcript::new(b"simple_protocol");
-        let five = Fr::from(5 as u128);
+        let five = Fr::from(5_u128);
 
         tr.append_scalar(b"five", &five);
         tr.append_scalar(b"five again", &five);
@@ -101,7 +101,7 @@ mod tests {
     #[test]
     fn test_vector_3() {
         let mut tr = Transcript::new(b"simple_protocol");
-        let one = Fr::from(1 as u128);
+        let one = Fr::from(1_u128);
         let minus_one = -one;
 
         tr.append_scalar(b"-1", &minus_one);


### PR DESCRIPTION
This PR addresses the TODO mentioned in the subject line, as well as fix some clippy-warning-causing issues.